### PR TITLE
React router

### DIFF
--- a/client/Dockerfile-dev
+++ b/client/Dockerfile-dev
@@ -1,6 +1,5 @@
 FROM node:16.13
 WORKDIR /usr/src/gradeflippr
-RUN npm install webpack
 COPY package*.json /usr/src/gradeflippr/
 RUN npm install
 RUN mkdir -p node_modules/.cache && chmod -R 777 node_modules/.cache

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -22,10 +22,13 @@
         "@types/react-dom": "^18.0.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.1",
-        "typescript": "^4.7.4",
         "web-vitals": "^2.1.4",
         "webrtc": "^1.14.1"
+      },
+      "devDependencies": {
+        "typescript": "^4.8.2"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -8862,6 +8865,14 @@
         "he": "bin/he"
       }
     },
+    "node_modules/history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -14556,6 +14567,30 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+      "dependencies": {
+        "history": "^5.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
+      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+      "dependencies": {
+        "history": "^5.2.0",
+        "react-router": "6.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
     "node_modules/react-scripts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
@@ -16299,9 +16334,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -23707,6 +23742,14 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
+    "history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "requires": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
     "hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -27699,6 +27742,23 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
     },
+    "react-router": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+      "requires": {
+        "history": "^5.2.0"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
+      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+      "requires": {
+        "history": "^5.2.0",
+        "react-router": "6.3.0"
+      }
+    },
     "react-scripts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
@@ -29008,9 +29068,9 @@
       }
     },
     "typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw=="
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/client/package.json
+++ b/client/package.json
@@ -17,8 +17,8 @@
     "@types/react-dom": "^18.0.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
-    "typescript": "^4.7.4",
     "web-vitals": "^2.1.4",
     "webrtc": "^1.14.1"
   },
@@ -46,5 +46,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "typescript": "^4.8.2"
   }
 }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,30 +1,28 @@
-// import React from 'react';
-// import logo from './logo.svg';
-// import './App.css';
-// import LoginPage from './pages/logInPage'
+import React from 'react';
+import { Routes, Route } from 'react-router-dom';
+import './App.css';
+import LoginPage from './pages/logInPage';
+import { UnprotectedLayout } from './components/UnprotectedLayout';
+import { ProtectedLayout } from './components/ProtectedLayout';
+import { HomePage } from './pages/Home';
+import { SignupPage } from './pages/SignupPage';
+import { StudentDashboard } from './pages/StudentDashboard';
+import { TutorDashboard } from './pages/TutorDashboard';
+// import { TutorDashboard } from './pages/TutorDashboard';
 
-// function App() {
-//   return (
-//     // <div className="App">
-//     //   <header className="App-header">
-//     //     <img src={logo} className="App-logo" alt="logo" />
-//     //     <p>
-//     //       Edit <code>src/App.tsx</code> and save to reload.
-//     //     </p>
-//     //     <a
-//     //       className="App-link"
-//     //       href="https://reactjs.org"
-//     //       target="_blank"
-//     //       rel="noopener noreferrer"
-//     //     >
-//     //       Learn React
-//     //     </a>
-//     //   </header>
-//     // </div>
-//     // <div> 
-//     <LoginPage/>
-//     // </div>
-//   );
-// }
+export default function App() {
+  return (
+    <Routes>
+      <Route element={<UnprotectedLayout />} >
+        <Route path="/" element={<HomePage />} />
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/signup" element={<SignupPage />} />
+      </Route>
 
-// export default App;
+      <Route path="/dashboard" element={<ProtectedLayout />}>
+        <Route path="student" element={<StudentDashboard />} />
+        <Route path='tutor' element={<TutorDashboard />} />
+      </Route>
+    </Routes>
+  );
+}

--- a/client/src/components/AppBar.jsx
+++ b/client/src/components/AppBar.jsx
@@ -1,0 +1,119 @@
+import * as React from 'react';
+import MuiAppBar from '@mui/material/AppBar';
+import Box from '@mui/material/Box';
+import Toolbar from '@mui/material/Toolbar';
+import IconButton from '@mui/material/IconButton';
+import Typography from '@mui/material/Typography';
+import Menu from '@mui/material/Menu';
+import MenuIcon from '@mui/icons-material/Menu';
+import Container from '@mui/material/Container';
+
+import Button from '@mui/material/Button';
+
+import MenuItem from '@mui/material/MenuItem';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+
+export const AppBar = ({ pages }) => {
+  const [anchorElNav, setAnchorElNav] = React.useState(null);
+  const navigate = useNavigate();
+  const { user, logout } = useAuth();
+
+  const handleOpenNavMenu = (event) => {
+    setAnchorElNav(event.currentTarget);
+  };
+
+  const handleCloseNavMenu = (path) => {
+    setAnchorElNav(null);
+    if (path) {
+      navigate(path);
+    }
+  };
+
+  return (
+    <MuiAppBar position="static">
+      <Container maxWidth="xl">
+        <Toolbar disableGutters>
+          <Typography
+            variant="h6"
+            noWrap
+            component="div"
+            sx={{ mr: 2, display: { xs: 'none', md: 'flex' } }}
+          >
+            React Router Auth
+          </Typography>
+
+          <Box sx={{ flexGrow: 1, display: { xs: 'flex', md: 'none' } }}>
+            <IconButton
+              size="large"
+              aria-label="account of current user"
+              aria-controls="menu-appbar"
+              aria-haspopup="true"
+              onClick={handleOpenNavMenu}
+              color="inherit"
+            >
+              <MenuIcon />
+            </IconButton>
+            <Menu
+              id="menu-appbar"
+              anchorEl={anchorElNav}
+              anchorOrigin={{
+                vertical: 'bottom',
+                horizontal: 'left',
+              }}
+              keepMounted
+              transformOrigin={{
+                vertical: 'top',
+                horizontal: 'left',
+              }}
+              open={Boolean(anchorElNav)}
+              onClose={handleCloseNavMenu}
+              sx={{
+                display: { xs: 'block', md: 'none' },
+              }}
+            >
+              {pages?.map((page) => (
+                <MenuItem key={page.label} onClick={() => handleCloseNavMenu(page.path)}>
+                  <Typography textAlign="center">{page.label}</Typography>
+                </MenuItem>
+              ))}
+              {!!user && (
+                <MenuItem key={'logout'} onClick={logout}>
+                  <Typography textAlign="center">Logout</Typography>
+                </MenuItem>
+              )}
+            </Menu>
+          </Box>
+          <Typography
+            variant="h6"
+            noWrap
+            component="div"
+            sx={{ flexGrow: 1, display: { xs: 'flex', md: 'none' } }}
+          >
+            React Router Auth
+          </Typography>
+          <Box sx={{ flexGrow: 1, display: { xs: 'none', md: 'flex' } }}>
+            {pages?.map((page) => (
+              <Button
+                key={page.label}
+                onClick={() => handleCloseNavMenu(page.path)}
+                sx={{ my: 2, color: 'white', display: 'block' }}
+              >
+                {page.label}
+              </Button>
+            ))}
+            {!!user && (
+              <Button
+                key={'logout'}
+                onClick={logout}
+                sx={{ my: 2, color: 'white', display: 'block' }}
+              >
+                {'logout'}
+              </Button>
+            )}
+          </Box>
+        </Toolbar>
+      </Container>
+    </MuiAppBar>
+  );
+};

--- a/client/src/components/BasicPage.jsx
+++ b/client/src/components/BasicPage.jsx
@@ -1,0 +1,24 @@
+import Container from '@mui/material/Container';
+import Avatar from '@mui/material/Avatar';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+
+export const BasicPage = ({ title, icon }) => {
+  return (
+    <Container component="main" maxWidth="xs">
+      <Box
+        sx={{
+          marginTop: 8,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+        }}
+      >
+        <Avatar sx={{ m: 1, bgcolor: 'primary.main' }}>{icon}</Avatar>
+        <Typography component="h1" variant="h5">
+          {title}
+        </Typography>
+      </Box>
+    </Container>
+  );
+};

--- a/client/src/components/ProtectedLayout.jsx
+++ b/client/src/components/ProtectedLayout.jsx
@@ -1,0 +1,23 @@
+import { Navigate, useOutlet } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+import { AppBar } from './AppBar';
+
+export const ProtectedLayout = () => {
+  const { user } = useAuth();
+  const outlet = useOutlet();
+
+  if (user) {
+    return <Navigate to="/dashboard/student" replace />;
+  }
+  return (
+    <div>
+      <AppBar
+        pages={[
+          { label: 'Home', path: '/' },
+          { label: 'Login', path: '/login' },
+        ]}
+      />
+      {outlet}
+    </div>
+  );
+};

--- a/client/src/components/UnprotectedLayout.jsx
+++ b/client/src/components/UnprotectedLayout.jsx
@@ -1,0 +1,23 @@
+import { Navigate, useOutlet } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+import { AppBar } from './AppBar';
+
+export const UnprotectedLayout = () => {
+  const { user } = useAuth();
+  const outlet = useOutlet();
+
+  if (!user === null) {
+    return <Navigate to="/dashboard/student" replace />;
+  }
+  return (
+    <div>
+      <AppBar
+        pages={[
+          { label: 'Home', path: '/' },
+          { label: 'Login', path: '/login' },
+        ]}
+      />
+      {outlet}
+    </div>
+  );
+};

--- a/client/src/hooks/useAuth.js
+++ b/client/src/hooks/useAuth.js
@@ -1,0 +1,39 @@
+import { createContext, useContext, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useLocalStorage } from './useLocalStorage';
+
+const AuthContext = createContext();
+console.log('IN useAuth')
+
+export const AuthProvider = ({ children }) => {
+  console.log('IN AuthProvider')
+  const [user, setUser] = useLocalStorage('user', null);
+  console.log(`USER: ${user}, setUser: ${JSON.stringify(setUser)}`);
+  const navigate = useNavigate();
+
+  const login = async (data) => {
+    setUser(data);
+    navigate('/dashboard/student', { replace: true });
+  };
+
+  const logout = () => {
+    setUser(null);
+    navigate('/', { replace: true });
+  };
+
+  const value = useMemo(
+    () => ({
+      user,
+      login,
+      logout,
+    }),
+    [user]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = () => {
+  const value = useContext(AuthContext);
+  return value;
+};

--- a/client/src/hooks/useLocalStorage.js
+++ b/client/src/hooks/useLocalStorage.js
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+
+export const useLocalStorage = (keyName, defaultValue) => {
+  const [storedValue, setStoredValue] = useState(() => {
+    try {
+      const value = window.localStorage.getItem(keyName);
+
+      if (!value === null) {
+        return JSON.parse(value);
+      } else {
+        window.localStorage.setItem(keyName, JSON.stringify(defaultValue));
+        return defaultValue;
+      }
+    } catch (err) {
+      return defaultValue;
+    }
+  });
+
+  const setValue = (newValue) => {
+    try {
+      window.localStorage.setItem(keyName, JSON.stringify(newValue));
+    } catch (err) {}
+    setStoredValue(newValue);
+  };
+
+  return [storedValue, setValue];
+};

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,14 +1,22 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
-import LoginPage from './pages/logInPage';
 import reportWebVitals from './reportWebVitals';
+import { StrictMode } from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import { AuthProvider } from './hooks/useAuth'
+
+import App from "./App";
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
-  <React.StrictMode>
-    <LoginPage />
-  </React.StrictMode>
+  <StrictMode>
+    <BrowserRouter>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </BrowserRouter>
+  </StrictMode>
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -1,0 +1,6 @@
+import { BasicPage } from '../components/BasicPage';
+import Home from '@mui/icons-material/Home';
+
+export const HomePage = () => {
+  return <BasicPage title="Home Page" icon={<Home />} />;
+};

--- a/client/src/pages/SignupPage.tsx
+++ b/client/src/pages/SignupPage.tsx
@@ -1,0 +1,6 @@
+import { BasicPage } from '../components/BasicPage';
+import AppRegistrationIcon from '@mui/icons-material/AppRegistration';
+
+export const SignupPage = () => {
+  return <BasicPage title="Signup Page" icon={<AppRegistrationIcon />} />;
+};

--- a/client/src/pages/StudentDashboard.jsx
+++ b/client/src/pages/StudentDashboard.jsx
@@ -1,0 +1,6 @@
+import { BasicPage } from '../components/BasicPage';
+import SchoolIcon from '@mui/icons-material/School';
+
+export const StudentDashboard = () => {
+  return <BasicPage title="Student Dashboard" icon={<SchoolIcon />} />;
+};

--- a/client/src/pages/TutorDashboard.jsx
+++ b/client/src/pages/TutorDashboard.jsx
@@ -1,0 +1,6 @@
+import { BasicPage } from '../components/BasicPage';
+import StarIcon from '@mui/icons-material/Star';
+
+export const TutorDashboard = () => {
+  return <BasicPage title="Tutor Dashboard" icon={<StarIcon />} />;
+};

--- a/client/src/pages/logInPage.tsx
+++ b/client/src/pages/logInPage.tsx
@@ -5,14 +5,15 @@ import CssBaseline from '@mui/material/CssBaseline';
 import TextField from '@mui/material/TextField';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Checkbox from '@mui/material/Checkbox';
-import Link from '@mui/material/Link';
+import Link from "@mui/material/Link";
+import { Link as RouterLink } from 'react-router-dom';
 import Paper from '@mui/material/Paper';
-import Box from '@mui/material/Box';    
+import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import Typography from '@mui/material/Typography';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
-import studentPhoto from '../assets/students.png'
+import studentPhoto from '../assets/students.png';
 
 function Copyright(props: any) {
   return (
@@ -99,12 +100,7 @@ export default function logInPage() {
                 control={<Checkbox value="remember" color="primary" />}
                 label="Remember me"
               />
-              <Button
-                type="submit"
-                fullWidth
-                variant="contained"
-                sx={{ mt: 3, mb: 2 }}
-              >
+              <Button type="submit" fullWidth variant="contained" sx={{ mt: 3, mb: 2 }}>
                 Sign In
               </Button>
               <Grid container>
@@ -114,9 +110,11 @@ export default function logInPage() {
                   </Link>
                 </Grid>
                 <Grid item>
-                  <Link href="#" variant="body2">
-                    {"Don't have an account? Sign Up"}
-                  </Link>
+                  <RouterLink to="/signup">
+                    <Link href="#" variant="body2">
+                      {"Don't have an account? Sign Up"}
+                    </Link>
+                  </RouterLink>
                 </Grid>
               </Grid>
               <Copyright sx={{ mt: 5 }} />


### PR DESCRIPTION
_How to write a PR request in GradeFlippr_

## Brief Description

New Feature: Frontend Routing with User Context
Bug Fix: Removed extra webpack import from Dockerfile-dev

## Extended Description

-Created base Frontend Routing via nested React Route statements in App. 
-Wrapped it all in a Context Provider that provides default ('null') user state and allows it to be updated and referenced from children components.
-Renamed and restructured component files
-Added 'hooks' dir in /src to hold custom hook 'useAuth' and dependency 'useLocalStorage' for caching user state updates
-Added boilerplate 'StudentDashboard' and 'TutorDashboard' pages in order to build out full Routing. These will be replaced with actual pages later.
-Removed webpack import statement from Dockerfile-dev

**Verification of Functionality:**

Tested functionality with 'npm run start'. While we don't have db connection yet (ie no auth/login access to protected Dashboard pages), I confirmed Routing works between unprotected 'LogIn' and 'SignUp' pages. The current structure which uses a Home page can be adjusted as needed. See recording.

 [FrontEnd Routing - Initial](https://vimeo.com/743504356/0fb29a05c2)